### PR TITLE
Check initial transcription is final

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -314,7 +314,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 self.conversation.logger.info(
                     f"BufferCancel? {self.buffer_check_task.cancel()}"
                 )
-            if self.initial_message:
+            if self.initial_message and transcription.is_final:
                 await self.conversation.send_initial_message(self.initial_message)
                 self.initial_message = None
                 return


### PR DESCRIPTION
Currently, we are not checking if the initial thing a person says on an outbound call is a finalized message. So, when the bot hears it, it will respond to first the semi-finalized message, then the finalized one

In this change, we make sure that the bot only responds to the finalized transcription