### PR TITLE
Fix the partial transcription bug

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -318,6 +318,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 await self.conversation.send_initial_message(self.initial_message)
                 self.initial_message = None
                 return
+            if not transcription.is_final:
+                return
             stashed_buffer = deepcopy(self.buffer)
             # Broadcast an interrupt and set the buffer status to DISCARD
             await self.conversation.broadcast_interrupt()


### PR DESCRIPTION
Currently the agent is responding to partially finalized transcriptions. We need to make sure the person is done talking before responding