### PR TITLE
add setup function

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -69,6 +69,12 @@ from vocode.streaming.utils import create_conversation_id, get_chunk_size_per_se
 from vocode.streaming.utils.conversation_logger_adapter import wrap_logger
 from vocode.streaming.utils.events_manager import EventsManager
 from vocode.streaming.utils.goodbye_model import GoodbyeModel
+from vocode.streaming.utils.setup_tracer import (
+    end_span,
+    setup_tracer,
+    span_event,
+    start_span_in_ctx,
+)
 from vocode.streaming.utils.state_manager import ConversationStateManager
 from vocode.streaming.utils.worker import (
     AsyncQueueWorker,
@@ -81,6 +87,8 @@ from vocode.streaming.utils.worker import (
 
 from telephony_app.models.call_type import CallType
 from telephony_app.utils.call_information_handler import update_call_transcripts
+
+tracer = setup_tracer()
 
 OutputDeviceType = TypeVar("OutputDeviceType", bound=BaseOutputDevice)
 

--- a/vocode/streaming/utils/setup_tracer.py
+++ b/vocode/streaming/utils/setup_tracer.py
@@ -1,0 +1,62 @@
+# vocode/streaming/utils/setup_tracer.py
+
+import os
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.trace import Span, Status, StatusCode
+
+tracer = trace.get_tracer(__name__)
+
+
+def setup_tracer():
+    """
+    Setup the tracer for the application based on the environment.
+    Environment variable ENV should be set to "prod" for production environment and "dev" for development environment.
+    """
+    try:
+        tracer_provider = TracerProvider()
+        project_id = os.getenv("GOOGLE_CLOUD_PROJECT", "default_project_id")
+        cloud_trace_exporter = CloudTraceSpanExporter(project_id=project_id)
+        if os.getenv("ENV") == "dev":
+            tracer_provider.add_span_processor(BatchSpanProcessor(cloud_trace_exporter))
+            trace.set_tracer_provider(tracer_provider)
+        return trace.get_tracer(__name__)
+    except Exception as e:
+        print(f"Failed to setup tracer: {str(e)}")
+        return trace.get_tracer(__name__)
+
+
+def span_event(span: Span, event_name: str, event_data: dict):
+    if span is None:
+        return
+    if span.is_recording():
+        span.add_event(event_name, event_data)
+
+
+def start_span_in_ctx(
+    name: str,
+    parent_span: Span,
+    attributes: Optional[dict] = None,
+):
+    if parent_span is None:
+        return None
+    elif not parent_span.is_recording():
+        return None
+    else:
+        ctx = trace.set_span_in_context(parent_span)
+        return tracer.start_span(
+            name=name,
+            context=ctx,
+            attributes=attributes,
+        )
+
+
+def end_span(span: Span):
+    if span is None:
+        return
+    if span.is_recording():
+        span.end()

--- a/vocode/streaming/utils/setup_tracer.py
+++ b/vocode/streaming/utils/setup_tracer.py
@@ -21,7 +21,7 @@ def setup_tracer():
         tracer_provider = TracerProvider()
         project_id = os.getenv("GOOGLE_CLOUD_PROJECT", "default_project_id")
         cloud_trace_exporter = CloudTraceSpanExporter(project_id=project_id)
-        if os.getenv("ENV") == "dev":
+        if os.getenv("ENV") == "prod":
             tracer_provider.add_span_processor(BatchSpanProcessor(cloud_trace_exporter))
             trace.set_tracer_provider(tracer_provider)
         return trace.get_tracer(__name__)


### PR DESCRIPTION
```
app-1    | warnings.warn(
app-1    | Downloading: "https://github.com/snakers4/silero-vad/zipball/master" to /root/.cache/torch/hub/master.zip
app-1    | [nltk_data] Downloading package punkt to /root/nltk_data...
app-1    | [nltk_data]   Unzipping tokenizers/punkt.zip.
app-1    | WARNING:google.auth.compute_engine._metadata:Compute Engine Metadata server unavailable on attempt 1 of 3. Reason: timed out
app-1    | WARNING:google.auth.compute_engine._metadata:Compute Engine Metadata server unavailable on attempt 2 of 3. Reason: [Errno 111] Connection refused
app-1    | WARNING:google.auth.compute_engine._metadata:Compute Engine Metadata server unavailable on attempt 3 of 3. Reason: [Errno 111] Connection refused
app-1    | WARNING:google.auth._default:Authentication failed using Compute Engine authentication due to unavailable metadata server.
app-1    | INFO:telephony_app.main:Set up events endpoint at https://35928477d8f0.ngrok.app/events
app-1    | INFO:telephony_app.main:Set up recordings endpoint at https://35928477d8f0.ngrok.app/recordings/{conversation_id}
app-1    | INFO:     Started server process [7]
app-1    | INFO:     Waiting for application startup.
app-1    | INFO:     Application startup complete.
app-1    | INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
```
no auth and successful call. 