### PR TITLE
one span to rule them all

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -837,6 +837,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             logger or logging.getLogger(__name__),
             conversation_id=self.id,
         )
+        self.conversation_span = tracer.start_span(f"conversation::{self.id}")
         self.logger.debug(f"Conversation ID: {self.id}")
         # threadingevent
         self.stop_event = threading.Event()
@@ -993,6 +994,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.transcriptions_worker.block_inputs = False
 
     async def send_initial_message(self, initial_message: BaseMessage):
+        initial_message_span = start_span_in_ctx(
+            name="send_initial_message", parent_span=self.conversation_span
+        )
         # TODO: configure if initial message is interruptible
         initial_message_tracker = asyncio.Event()
         agent_response_event = (
@@ -1005,6 +1009,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.agent_responses_worker.consume_nonblocking(agent_response_event)
         await initial_message_tracker.wait()
         self.transcriber.unmute()
+        end_span(initial_message_span)
 
     async def check_for_idle(self):
         """Terminates the conversation after 15 seconds if no activity is detected"""
@@ -1439,6 +1444,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
     async def terminate(self):
         self.mark_terminated()
+        end_span(self.conversation_span)
         await self.broadcast_interrupt()
         if self.synthesis_results_worker.current_task:
             self.synthesis_results_worker.current_task.cancel()

--- a/vocode/streaming/utils/setup_tracer.py
+++ b/vocode/streaming/utils/setup_tracer.py
@@ -19,7 +19,7 @@ def setup_tracer():
     """
     try:
         tracer_provider = TracerProvider()
-        project_id = os.getenv("GOOGLE_CLOUD_PROJECT", "default_project_id")
+        project_id = "autocaller"
         cloud_trace_exporter = CloudTraceSpanExporter(project_id=project_id)
         if os.getenv("ENV") == "prod":
             tracer_provider.add_span_processor(BatchSpanProcessor(cloud_trace_exporter))


### PR DESCRIPTION
### `env==dev`
*no gcloud auth*
```
...
app-1    | WARNING:google.auth.compute_engine._metadata:Compute Engine Metadata server unavailable on attempt 1 of 3. Reason: timed out
app-1    | WARNING:google.auth.compute_engine._metadata:Compute Engine Metadata server unavailable on attempt 2 of 3. Reason: timed out
app-1    | WARNING:google.auth.compute_engine._metadata:Compute Engine Metadata server unavailable on attempt 3 of 3. Reason: [Errno 111] Connection refused
app-1    | WARNING:google.auth._default:Authentication failed using Compute Engine authentication due to unavailable metadata server.
...
app-1    | INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
```

inbound call connected. 

### After gcloud auth
```
...
app-1    | WARNING:google.auth._default:No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
...
app-1    | INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
```
Call Connected Traces added
![Screenshot 2024-09-12 at 12 31 50 AM](https://github.com/user-attachments/assets/7fafb99f-c2a8-4ace-bea9-0273a863c636)


### `env == "prod"`
Call connected, no tracing added (as expected)




