### PR TITLE
remove call end notificaton

### DIFF
--- a/vocode/streaming/telephony/conversation/twilio_call.py
+++ b/vocode/streaming/telephony/conversation/twilio_call.py
@@ -33,8 +33,6 @@ from telephony_app.models.call_status import CallStatus
 from telephony_app.utils.call_information_handler import (
     execute_status_update_by_telephony_id,
 )
-from telephony_app.utils.mirth_connector import send_message_to_mirth
-from telephony_app.utils.twilio_call_helper import send_call_end_notification
 
 
 class PhoneCallWebsocketAction(Enum):
@@ -178,13 +176,6 @@ class TwilioCall(Call[TwilioOutputDevice]):
                     json_transcript=json_transcript.dict() if json_transcript else None
                 )
             )
-            send_call_end_notification_task = asyncio.create_task(
-                send_call_end_notification(
-                    call_id=self.agent.agent_config.current_call_id,
-                    call_type=self.agent.agent_config.call_type,
-                )
-            )
-
             await asyncio.gather(
                 status_update_task, send_call_end_notification_task
             )  # , send_message_to_mirth_task)


### PR DESCRIPTION
removes the call end notification because we will call it in the autocaller repo instead. 

This PR indirectly depends on https://github.com/greymatter-labs/autocaller/pull/1214/files