### PR TITLE
basic memory handling

### DIFF
--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -130,7 +130,7 @@ class MemoryDependency(BaseModel):
 
 async def handle_memory_dep(
     memory_dep: MemoryDependency,
-    speak: Callable[[dict], None],
+    speak: Callable[[dict], Awaitable[None]],
     call_ai: Callable[[str, Dict[str, Any], Optional[str]], Awaitable[str]],
     retry: Callable[[Optional[str]], Awaitable[Any]],
 ):
@@ -140,7 +140,7 @@ async def handle_memory_dep(
     if memory is not "NONE":
         return await retry(memory)
 
-    speak(memory_dep["question"])
+    await speak(memory_dep["question"])
 
     async def resume():
         return await retry()

--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -526,7 +526,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         self.state_history.append(state)
         # self.logger.info(f"Current State: {state}")
         speak_message = lambda message: self.print_message(message)
-        call_ai = lambda prompt, tool, stop=None: self.call_ai(prompt, tool, stop)
+        call_ai = lambda prompt, tool=None, stop=None: self.call_ai(prompt, tool, stop)
 
         for memory_dep in state.get("memory_dependencies", []):
             cached_memory = memories.get(memory_dep["key"])

--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -523,7 +523,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         speak_message = lambda message: self.print_message(message)
         call_ai = lambda prompt, tool, stop=None: self.call_ai(prompt, tool, stop)
 
-        for memory_dep in state['memoryDependencies']:
+        for memory_dep in state.get('memoryDependencies', []):
             await handle_memory_dep(memory_dep=memory_dep, speak=speak_message, call_ai=call_ai)
 
         await self.print_start_message(state, start=start)

--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -137,10 +137,10 @@ async def handle_memory_dep(
 ):
     logger.info(f"handling memory dep {memory_dep}")
     memory = await call_ai(
-        f"try to extract the {memory_dep['key']}. If it's not in the conversation, return NOT FOUND"
+        f"try to extract the {memory_dep['key']}. If it's not in the conversation, return MISSING"
     )
-    logger.info(f"memory {memory}")
-    if memory is not "NOT FOUND":
+    logger.info(f"memory directly from AI: {memory}")
+    if memory != "MISSING":
         return await retry(memory)
 
     await speak(memory_dep["question"])

--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -137,10 +137,10 @@ async def handle_memory_dep(
 ):
     logger.info(f"handling memory dep {memory_dep}")
     memory = await call_ai(
-        f"try to extract the {memory_dep['key']}. If it's not in the conversation, return NONE"
+        f"try to extract the {memory_dep['key']}. If it's not in the conversation, return NOT FOUND"
     )
     logger.info(f"memory {memory}")
-    if memory is not "NONE":
+    if memory is not "NOT FOUND":
         return await retry(memory)
 
     await speak(memory_dep["question"])

--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -528,7 +528,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         speak_message = lambda message: self.print_message(message)
         call_ai = lambda prompt, tool, stop=None: self.call_ai(prompt, tool, stop)
 
-        for memory_dep in state.get("memoryDependencies", []):
+        for memory_dep in state.get("memory_dependencies", []):
             cached_memory = memories.get(memory_dep["key"])
             if not cached_memory:
 


### PR DESCRIPTION
the absolute bare minimum to handle memories

I wasn't going to have a cache at first, but ended up needing it to prevent us from asking the same question over and over again

how it works:

1. every state has an optional `memoryDependencies` field, and `handle_state` has a cache of `memories`
2. upon handing a state, we look for missing memories (first we check cache, then try to derive it from the conversation). If all memories are present, skip the rest of this workflow
3. for the first missing memory, ask the user to provide it
4. return to step 2