### PR TITLE
end call from streaming conversation

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -1477,6 +1477,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.mark_terminated()
         end_span(self.conversation_span)
         await self.broadcast_interrupt()
+        self.output_device.terminate()
+
         if self.synthesis_results_worker.current_task:
             self.synthesis_results_worker.current_task.cancel()
         self.events_manager.publish_event(
@@ -1505,7 +1507,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
             await self.agent.vector_db.tear_down()
         self.agent.terminate()
         self.logger.debug("Terminating output device")
-        self.output_device.terminate()
         self.logger.debug("Terminating speech transcriber")
         self.transcriber.terminate()
         self.logger.debug("Terminating transcriptions worker")


### PR DESCRIPTION
looks like streaming conversation is agnostic to the fact that it's a twilio call, or the fact that it's a call at all

TwilioCall extends Call which extends StreamingConversation, so it should be possible to put our functionality in TwilioCall. StreamingConversation calls `terminate` on idle here: https://github.com/greymatter-labs/vocode-python-main/blob/f4ec0d41d1ad7f55351bcb2a17580fd3226ea070/vocode/streaming/streaming_conversation.py#L985