### PR TITLE
remove duplicate outbound call recording creation

### DIFF
--- a/vocode/streaming/telephony/conversation/outbound_call.py
+++ b/vocode/streaming/telephony/conversation/outbound_call.py
@@ -1,21 +1,17 @@
 import logging
 from typing import Optional, Union
-from vocode import getenv
 
+from vocode import getenv
 from vocode.streaming.models.agent import AgentConfig
 from vocode.streaming.models.audio_encoding import AudioEncoding
-from vocode.streaming.models.synthesizer import (
-    SynthesizerConfig,
-)
+from vocode.streaming.models.synthesizer import SynthesizerConfig
 from vocode.streaming.models.telephony import (
     TwilioCallConfig,
     TwilioConfig,
     VonageCallConfig,
     VonageConfig,
 )
-from vocode.streaming.models.transcriber import (
-    TranscriberConfig,
-)
+from vocode.streaming.models.transcriber import TranscriberConfig
 from vocode.streaming.telephony.client.base_telephony_client import BaseTelephonyClient
 from vocode.streaming.telephony.client.twilio_client import TwilioClient
 from vocode.streaming.telephony.client.vonage_client import VonageClient
@@ -122,7 +118,7 @@ class OutboundCall:
             conversation_id=self.conversation_id,
             to_phone=self.to_phone,
             from_phone=self.from_phone,
-            record=self.telephony_client.get_telephony_config().record,
+            record=False,
             digits=self.digits,
         )
         if isinstance(self.telephony_client, TwilioClient):


### PR DESCRIPTION
Right now outbound calls create two recordings

`vocode/streaming/telephony/conversation/twilio_call.py`
```
if self.twilio_config.record:
  recordings_create_params = (
      self.twilio_config.extra_params.get("recordings_create_params")
      if self.twilio_config.extra_params
      else None
  )
  recording = (
      twilio_call_ref.recordings.create(**recordings_create_params)
      if recordings_create_params
      else twilio_call_ref.recordings.create()
  )
  self.logger.info(f"Recording: {recording.sid}")
```
`vocode/streaming/telephony/conversation/outbound_call.py`
```
self.telephony_id = await self.telephony_client.create_call(
    conversation_id=self.conversation_id,
    to_phone=self.to_phone,
    from_phone=self.from_phone,
    record=self.telephony_client.get_telephony_config().record,
    digits=self.digits,
)
```


Setting record to false in `outbound_call.py` removes the duplicate. 
https://app.opencall.ai/console/calls/WzEsICJwdWJsaWMiLCAiY2FsbHMiLCAxMTcwM10%3D

removing the recording from `twilio_call.py` seems to remove all recordings from inbound calls.