### PR TITLE
fix initial msg thresh

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -1015,7 +1015,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         # Start a timer to track when 2 seconds have passed
         start_time = time.time()
-        self.transcriber.VOLUME_THRESHOLD = 4000  # make it so high vad wont interrupt it, only a real transcription will
+        self.transcriber.VOLUME_THRESHOLD = 8000  # make it so high vad wont interrupt it, only a real transcription will
         previous_allow_interruptions = self.agent.agent_config.allow_interruptions
         # only run the loop if we're in outbound mode
         if self.agent.get_agent_config().call_type == CallType.OUTBOUND:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `VOLUME_THRESHOLD` to 8000 in `send_initial_message()` to prevent VAD interruptions during initial message sending in outbound calls.
> 
>   - **Behavior**:
>     - In `send_initial_message()` in `streaming_conversation.py`, increase `VOLUME_THRESHOLD` from 4000 to 8000 to prevent VAD interruptions during initial message sending in outbound calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=greymatter-labs%2Fvocode-python-main&utm_source=github&utm_medium=referral)<sup> for 9e0d9fe12ad0d67b1112a48b676ed6c081bc3f04. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->