### PR TITLE
Fix early bot interrupt attempt

### DIFF
--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -645,7 +645,8 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
             and message.get("improvise", True)
         ):
             original_message = message["message"]
-            constructed_guide = f"You previously communicated to the user: '{original_message}'. Rephrase your previous message. You must maintain its core meaning, tone and approximate length."
+            word_count = len(original_message.split())
+            constructed_guide = f"Rephrase this message in {word_count} words or less, keeping the same meaning and tone: '{original_message}'. Provide only the rephrased message."
             await self.guided_response(constructed_guide)
         else:
             if message["type"] == "verbatim":

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -288,6 +288,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 self.conversation.logger.debug(
                     "Ignoring transcription on initial message"
                 )
+                self.conversation.mark_last_action_timestamp()
                 return
             if (
                 self.conversation.agent.block_inputs
@@ -310,6 +311,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 self.conversation.logger.debug(
                     "Ignoring transcription since we are SPEAKING..."
                 )
+                self.conversation.mark_last_action_timestamp()
+                # clear the buffer
+                self.buffer.clear()
                 return
             # If the message is just "vad", handle it without resetting the buffer check
             if transcription.message.strip() == "vad":
@@ -666,6 +670,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 agent_response_message = typing.cast(
                     AgentResponseMessage, agent_response
                 )
+                self.conversation.mark_last_action_timestamp()
 
                 if self.conversation.filler_audio_worker is not None:
                     if (
@@ -1184,6 +1189,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         """
         self.logger.debug("Broadcasting interrupt")
         self.stop_event.set()
+        self.mark_last_action_timestamp()
         if isinstance(self.agent, CommandAgent):
             self.agent.stop = not self.agent.stop
         num_interrupts = 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves bot interruption handling and message processing in `StateAgent` and `StreamingConversation` for smoother interactions.
> 
>   - **Behavior**:
>     - In `state_agent.py`, rephrases messages to be within the word count of the original message, ensuring the same meaning and tone.
>     - In `streaming_conversation.py`, marks the last action timestamp and clears the buffer when ignoring transcriptions during speaking.
>     - Handles starting double quotes in translated messages by removing them if there's an odd number of quotes.
>   - **Functions**:
>     - `is_agent_speaking()` in `streaming_conversation.py` now checks additional queues to determine if the agent is speaking.
>     - `broadcast_interrupt()` in `streaming_conversation.py` marks the last action timestamp when broadcasting an interrupt.
>   - **Misc**:
>     - Minor logging adjustments in `streaming_conversation.py` to improve debugging information.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=greymatter-labs%2Fvocode-python-main&utm_source=github&utm_medium=referral)<sup> for ccd8500afad708525c81f43d244933ad44537b08. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->