### PR TITLE
intelligently make it cancel

### DIFF
--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -428,6 +428,16 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         )
         self.label_to_state_id = self.state_machine["labelToStateId"]
 
+    def cancel_stream(self):
+        self.stop = True
+        if (
+            self.resume_task
+            and not self.resume_task.done()
+            and not self.resume_task.cancelled()
+        ):
+            self.resume_task.cancel()
+            self.logger.info("Stream cancelled")
+
     def update_state_from_transcript(self, transcript: StateAgentTranscript):
         self.json_transcript = transcript
         self.chat_history = []
@@ -1178,6 +1188,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
             punctuation = [".", "!", "?", ",", ";", ":"]
             send_final_message = False
             async for chunk in stream:
+                await asyncio.sleep(0)
                 text_chunk = chunk.choices[0].delta.content
                 if text_chunk:
                     response_text += text_chunk

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -1200,6 +1200,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         Returns true if any events were interrupted - which is used as a flag for the agent (is_interrupt)
         """
+        self.agent.cancel_stream()
         self.logger.debug("Broadcasting interrupt")
         self.stop_event.set()
         self.mark_last_action_timestamp()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `cancel_stream` method to `StateAgent` and integrates it with `broadcast_interrupt` in `StreamingConversation` for task cancellation.
> 
>   - **Behavior**:
>     - Adds `cancel_stream()` method to `StateAgent` to set `stop` flag and cancel `resume_task` if it's not done or cancelled.
>     - Invokes `cancel_stream()` in `broadcast_interrupt()` in `StreamingConversation` to handle stream cancellation.
>   - **Misc**:
>     - Adds `await asyncio.sleep(0)` in `call_ai()` in `state_agent.py` to yield control during streaming.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=greymatter-labs%2Fvocode-python-main&utm_source=github&utm_medium=referral)<sup> for e5aa12119badb762d32b650b5e0fb6ff1b52cacd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->