### PR TITLE
fix tool interpolation

### DIFF
--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -867,7 +867,6 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                         action_result_after_user = msg
                     elif role == "message.bot" and msg and not bot_message_after_user:
                         bot_message_after_user = msg
-                        break
                 elif msg == last_user_message:
                     user_found = True
 


### PR DESCRIPTION
This bug was due to incorrect transcript processing. The transcript looks like this

1. [irrelevant prior history]
2. user triggers the action, i.e. “When is my appointment”. Assuming no interruptions, this becomes `last_user_message`
3. (optional) bot responds with some kind of filler message, i.e. “Sure thing!”. This becomes `bot_message_after_user`
4. we get an `action-finish` message. This should become `action_result_after_user`

Before this PR, we'd break the loop on step 3 and never set `action_result_after_user`. This causes the action result to be missing from the response prompt

open questions:
* this code is from August, how did it ever work? I've attached the relevant git blame
* what caused the error rate to suddenly spike?
* why was the logic originally written this way?
* will this play nicely with all the interruption edge cases? (since we don't really use interruptions+tools in prod right now, and this bug is quite severe, I'd like to skip testing this for now)

<img width="1049" alt="Screenshot 2024-10-23 at 8 15 51 PM" src="https://github.com/user-attachments/assets/6fdcd271-273c-48c5-8e33-45066d527bb8">
