### PR TITLE
remove input from action message in prompt

### DIFF
--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -1074,7 +1074,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
             pass
 
         return await saveActionResultAndMoveOn(
-            action_result=f"Action Completed: '{action_name}' completed with the following result:\ninput:'{input}'\noutput:\n{output}",
+            action_result=f"Action Completed: '{action_name}' completed with the following result:\n{output}",
             runtime_inputs=runtime_inputs,
         )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove input details from action result message in `run_action_and_return_input` in `state_agent.py`.
> 
>   - **Behavior**:
>     - In `run_action_and_return_input` in `state_agent.py`, removed `input` details from `action_result` message.
>     - The message now only includes `output` details after action completion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=greymatter-labs%2Fvocode-python-main&utm_source=github&utm_medium=referral)<sup> for afea1b05a46806b65b4ccc3651aa8566b5a65566. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->