### PR TITLE
fix None access

### DIFF
--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -514,7 +514,9 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         agent.json_transcript = state.json_transcript
         agent.current_state = state.current_state
         agent.logger = logger
-        agent.resume = lambda _: agent.handle_state(state.current_state)
+        agent.resume = lambda _: agent.handle_state(
+            state.current_state["id"] if state and state.current_state else "start"
+        )
         return agent
 
     def state_dump(self):


### PR DESCRIPTION
https://opencall-ai.slack.com/archives/C070ZK85GV6/p1733297107865239
Prevented agent from responding entirely.
### Logs from error
```
app-1    | INFO:telephony_app.main:[CallType.INBOUND:79310] Lead:yes
app-1    | ERROR:telephony_app.main:No intent task
app-1    | INFO:telephony_app.main:handle state None retry count 0
app-1    | ERROR:vocode.streaming.utils.worker:InterruptibleWorker
app-1    | Traceback (most recent call last):
app-1    | File "/code/local_vocode/vocode-python-main/vocode/streaming/utils/worker.py", line 228, in _run_loop
app-1    | await self.current_task
app-1    | File "/code/local_vocode/vocode-python-main/vocode/streaming/agent/base_agent.py", line 357, in process
app-1    | should_stop = await self.handle_generate_response(
app-1    | File "/code/local_vocode/vocode-python-main/vocode/streaming/agent/base_agent.py", line 253, in handle_generate_response
app-1    | function_call = await self.respond_with_functions(
app-1    | File "/code/local_vocode/vocode-python-main/vocode/streaming/agent/base_agent.py", line 518, in respond_with_functions
app-1    | response = await self.generate_completion(
app-1    | File "/code/local_vocode/vocode-python-main/vocode/streaming/agent/state_agent.py", line 774, in generate_completion
app-1    | resume_output = await self.resume_task
app-1    | File "/code/local_vocode/vocode-python-main/vocode/streaming/agent/state_agent.py", line 894, in handle_state
app-1    | if "start_of_block" in state:
app-1    | TypeError: argument of type 'NoneType' is not iterable
```