### PR TITLE
adjust azure synth get msg up to

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -1472,8 +1472,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
         # Added stop event check otherwise it will block other synthesis result tasks
         # even though we meant to cancel this one.
         sleep_interval = 0.1  # Mark last action every 0.1 seconds
-        remaining_sleep = total_time_sent - self.get_duration_spoken_seconds(
-            time_started_speaking
+        remaining_sleep = (
+            total_time_sent  # - self.get_duration_spoken_seconds(time_started_speaking)
         )
         while remaining_sleep > 0:
             next_sleep = min(sleep_interval, remaining_sleep)

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -13,6 +13,8 @@ from enum import Enum
 from typing import Any, Awaitable, Callable, Generic, Optional, Tuple, TypeVar
 
 import httpx
+from telephony_app.models.call_type import CallType
+
 from vocode.streaming.action.worker import ActionsWorker
 from vocode.streaming.agent.base_agent import (
     AgentInput,
@@ -27,9 +29,7 @@ from vocode.streaming.agent.base_agent import (
 from vocode.streaming.agent.bot_sentiment_analyser import BotSentimentAnalyser
 from vocode.streaming.agent.command_agent import CommandAgent
 from vocode.streaming.agent.state_agent import StateAgent
-from vocode.streaming.agent.utils import (
-    translate_message,
-)
+from vocode.streaming.agent.utils import translate_message
 from vocode.streaming.constants import (
     PER_CHUNK_ALLOWANCE_SECONDS,
     TEXT_TO_SPEECH_CHUNK_SIZE_SECONDS,
@@ -69,8 +69,6 @@ from vocode.streaming.utils.worker import (
     InterruptibleEvent,
     InterruptibleEventFactory,
 )
-
-from telephony_app.models.call_type import CallType
 
 tracer = setup_tracer()
 
@@ -1372,6 +1370,11 @@ class StreamingConversation(Generic[OutputDeviceType]):
             self.transcriber.get_transcriber_config().min_interrupt_confidence or 0
         )
 
+    def get_duration_spoken_seconds(self, time_started_speaking: float | None):
+        if time_started_speaking is None:
+            return 0
+        return time.perf_counter() - time_started_speaking
+
     async def send_speech_to_output(
         self,
         message: str,
@@ -1398,9 +1401,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         speech_data = bytearray()
         held_buffer = self.transcriptions_worker.buffer.to_message()
-        time_started_speaking = time.time()
         buffer_cleared = False
         total_time_sent = 0
+        time_started_speaking = None
         moved_back = False
         async for chunk_result in synthesis_result.chunk_generator:
 
@@ -1413,6 +1416,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 self.transcriptions_worker.block_inputs = True
                 self.transcriptions_worker.time_silent = 0.0
                 self.transcriptions_worker.triggered_affirmative = False
+                if time_started_speaking is None:
+                    time_started_speaking = time.perf_counter()
                 # self.logger.debug(f"Sending chunk, len {len(speech_data)}")
 
                 if self.agent.agent_config.allow_interruptions:
@@ -1433,6 +1438,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 speech_data = bytearray()
 
         if not stop_event.is_set():
+            if time_started_speaking is None:
+                time_started_speaking = time.perf_counter()
             self.logger.debug(f"Sending final chunk, len {len(speech_data)}")
             await self.output_device.consume_nonblocking(speech_data)
             self.transcriptions_worker.time_silent = 0.0
@@ -1465,7 +1472,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
         # Added stop event check otherwise it will block other synthesis result tasks
         # even though we meant to cancel this one.
         sleep_interval = 0.1  # Mark last action every 0.1 seconds
-        remaining_sleep = total_time_sent
+        remaining_sleep = total_time_sent - self.get_duration_spoken_seconds(
+            time_started_speaking
+        )
         while remaining_sleep > 0:
             next_sleep = min(sleep_interval, remaining_sleep)
             await asyncio.sleep(next_sleep)
@@ -1476,6 +1485,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
             self.mark_last_action_timestamp()
             self.turn_speech_time += next_sleep
             remaining_sleep -= next_sleep
+            # message_sent = synthesis_result.get_message_up_to(self.get_duration_spoken_seconds(time_started_speaking))
+            # self.logger.info(f"{message_sent=} {self.get_duration_spoken_seconds(time_started_speaking)=}")
             if self.turn_speech_time > 3:
                 self.logger.debug(f"Turn speech time: {self.turn_speech_time}")
                 buffer_cleared = True

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -370,9 +370,8 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
     ) -> str:
         if len(ssml_parts) > 1:
             return message
-        else:
-            ssml = ssml_parts[0]
         try:
+            ssml = ssml_parts[0]
             events = word_boundary_event_pool.get_events_sorted()
             if len(events) == 0:
                 return message

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -9,7 +9,7 @@ import tempfile
 # get req for wav as wav
 import wave
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, TypedDict
 from xml.etree import ElementTree
 
 import aiohttp
@@ -43,14 +43,11 @@ ElementTree.register_namespace("", NAMESPACES[""])
 ElementTree.register_namespace("mstts", NAMESPACES["mstts"])
 
 
-from typing import List, TypedDict
-
-
 class WordBoundaryEvent(TypedDict):
     text: str
     text_offset: int
     audio_offset: float
-    boundary_type: int
+    boundary_type: speechsdk.SpeechSynthesisBoundaryType
 
 
 class WordBoundaryEventPool:
@@ -63,7 +60,9 @@ class WordBoundaryEventPool:
                 "text": event.text,
                 "text_offset": event.text_offset,
                 "audio_offset": (event.audio_offset + 5000) / (10000 * 1000),
-                "boundary_type": event.boundary_type,
+                "boundary_type": speechsdk.SpeechSynthesisBoundaryType(
+                    event.boundary_type
+                ),
             }
         )
 
@@ -383,7 +382,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
 
                     # the last event that has been spoken
                     current_event = events[index - 1]
-
+                    # self.logger.info(f"{current_event=}")
                     # an events text_offset is the index of the first character of the events text in the ssml string
                     current_char_index = current_event["text_offset"] + len(
                         current_event["text"]

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -16,6 +16,7 @@ import aiohttp
 import azure.cognitiveservices.speech as speechsdk
 import numpy as np
 from opentelemetry.context.context import Context
+
 from vocode import getenv
 from vocode.streaming.agent.bot_sentiment_analyser import BotSentiment
 from vocode.streaming.models.audio_encoding import AudioEncoding
@@ -52,7 +53,7 @@ class WordBoundaryEventPool:
                 "text": event.text,
                 "text_offset": event.text_offset,
                 "audio_offset": (event.audio_offset + 5000) / (10000 * 1000),
-                "boudary_type": event.boundary_type,
+                "boundary_type": event.boundary_type,
             }
         )
 
@@ -358,11 +359,15 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
         word_boundary_event_pool: WordBoundaryEventPool,
     ) -> str:
         events = word_boundary_event_pool.get_events_sorted()
-        # for event in events:
-        #     if event["audio_offset"] > seconds:
-        #         ssml_fragment = ssml[: event["text_offset"]]
-        #         # TODO: this is a little hacky, but it works for now
-        #         return ssml_fragment.split(">")[-1]
+        message_index: int = events[0]["text_offset"]  # Start of the message
+        for index, event in enumerate(events):
+            if event["audio_offset"] > seconds:
+                current_index = events[index - 1]["text_offset"] + len(
+                    events[index - 1]["text"]
+                )
+                message_up_to = ssml[message_index:current_index]
+                # self.logger.debug(f"{message_up_to=} {current_index=}")
+                return message_up_to
         return message
 
     async def create_speech(
@@ -486,6 +491,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
                     async for chunk in dtmf_audio_generator(tone):
                         yield chunk
 
+        # full_ssml = await self.create_ssml(message.text, bot_sentiment=bot_sentiment)
         return SynthesisResult(
             combined_generator(),
             lambda seconds: self.get_message_up_to(

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -380,15 +380,14 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
                     if index == 0:
                         return message
 
-                    # the last event that has been spoken
+                    # Get last spoken event
                     current_event = events[index - 1]
-                    # self.logger.info(f"{current_event=}")
-                    # an events text_offset is the index of the first character of the events text in the ssml string
+                    # Calculate ending character position
                     current_char_index = current_event["text_offset"] + len(
                         current_event["text"]
                     )
                     message_up_to = ssml[message_start_index:current_char_index]
-                    # Verify message_up_to is a substring of message
+                    # Validate substring
                     if message_up_to not in message:
                         self.logger.error(
                             f"Message up to {message_up_to} is not a substring of message {message}"


### PR DESCRIPTION
Logs from when full_ssml was uncommented and some streaming conversation changes to actually call msg_sent during consumption and await.

```
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No' current_index=160
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No rush' current_index=165
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No rush' current_index=165
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No rush at' current_index=168
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No rush at all' current_index=172
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No rush at all, take' current_index=178
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No rush at all, take your' current_index=183
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_up_to='No rush at all, take your time' current_index=188
... from streaming_conversation.py
app-1    | DEBUG:telephony_app.main:[Y833HZXYm6RWLNGMeHkS7w] message_sent='No rush at all, take your time.'
```