### PR TITLE
Json transcript partials 

### DIFF
--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -19,6 +19,7 @@ from typing import (
 
 from opentelemetry import trace
 from opentelemetry.trace import Span
+
 from vocode.streaming.action.factory import ActionFactory
 from vocode.streaming.action.phone_call_action import (
     TwilioPhoneCallAction,
@@ -299,6 +300,7 @@ class RespondAgent(BaseAgent[AgentConfigType]):
         assert self.transcript is not None
         try:
             agent_input = item.payload
+            self.logger.debug(f"{agent_input=}")
             if isinstance(agent_input, TranscriptionAgentInput):
                 transcription = typing.cast(
                     TranscriptionAgentInput, agent_input
@@ -378,7 +380,7 @@ class RespondAgent(BaseAgent[AgentConfigType]):
                 except asyncio.TimeoutError:
                     self.logger.debug("Goodbye detection timed out")
         except asyncio.CancelledError:
-            pass
+            self.logger.debug("Agent input processing cancelled")
 
     def _get_action_config(self, function_name: str) -> Optional[ActionConfig]:
         if self.agent_config.actions is None:

--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -642,8 +642,6 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         speak: bool = True,
         state_agent_transcript_messages_added: List[StateAgentTranscriptMessage] = [],
     ):
-        if role == "message.bot" or role == "human":
-            self.logger.info(f"Updating history with role: {role}, message: {message}")
         TranscriptEntry = None
         if role == "human":
             while self.chat_history and self.chat_history[-1][0] == "human":
@@ -1599,7 +1597,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                                 TranscriptMessage = StateAgentTranscriptMessage(
                                     role="message.bot",
                                     message=interpolated_content,
-                                    message_sent=interpolated_content,
+                                    message_sent="",
                                 )
                                 state_agent_transcript_messages_added.append(
                                     TranscriptMessage
@@ -1647,7 +1645,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                 TranscriptMessage = StateAgentTranscriptMessage(
                     role="message.bot",
                     message=interpolated_content,
-                    message_sent=interpolated_content,
+                    message_sent="",
                 )
                 state_agent_transcript_messages_added.append(TranscriptMessage)
                 self.produce_interruptible_agent_response_event_nonblocking(

--- a/vocode/streaming/agent/state_agent.py
+++ b/vocode/streaming/agent/state_agent.py
@@ -7,6 +7,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, TypedD
 
 from openai import AsyncOpenAI
 from pydantic import BaseModel
+
 from vocode import getenv
 from vocode.streaming.action.phone_call_action import TwilioPhoneCallAction
 from vocode.streaming.agent.base_agent import (
@@ -133,7 +134,7 @@ async def handle_memory_dep(
         "question"
     ].get("message", "")
     logger.error(f"message_to_say |  {message_to_say}")
-    output, streamed = await call_ai(
+    output, state_agent_transcript_messages_added, streamed = await call_ai(
         f"""You are trying to obtain the following information: '{memory_dep['key']}'.
 
 What it means: '{memory_dep['description'] or 'No extra details given.'}'.
@@ -171,7 +172,11 @@ Your response must be a JSON containing the keys '{memory_dep['key']}' and 'outp
             }
         )
 
-    await speak({"type": "verbatim", "message": message, "improvise": False}, streamed)
+    await speak(
+        {"type": "verbatim", "message": message, "improvise": False},
+        streamed,
+        state_agent_transcript_messages_added,
+    )
 
     async def resume(human_input: str):
         return await retry()
@@ -323,7 +328,9 @@ async def handle_options(
             f"{ai_options_str}\n\n"
             "Always return a number from the above list. Return the number of the condition that best applies."
         )
-    response, streamed = await call_ai(prompt, tool, stream_output=True)
+    response, state_agent_transcript_messages_added, streamed = await call_ai(
+        prompt, tool, stream_output=True
+    )
 
     logger.info(f"Chose condition: {response}")
     next_state_label = None
@@ -355,7 +362,9 @@ async def handle_options(
                 "- If the user asked a question, provide a concise answer and then ask for a clear answer if you are waiting for one.\n"
                 "- Ensure not to suggest any actions or offer alternatives.\n"
             )
-            output, streamed = await call_ai(prompt, tool, stream_output=True)
+            output, state_agent_transcript_messages_added, streamed = await call_ai(
+                prompt, tool, stream_output=True
+            )
             output = output[output.find("{") : output.find("}") + 1]
             parsed_output = parse_llm_json(output)
             to_speak = parsed_output["response"]
@@ -631,8 +640,11 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         action_name: Optional[str] = None,
         runtime_inputs: Optional[dict] = None,
         speak: bool = True,
+        state_agent_transcript_messages_added: List[StateAgentTranscriptMessage] = [],
     ):
-
+        if role == "message.bot" or role == "human":
+            self.logger.info(f"Updating history with role: {role}, message: {message}")
+        TranscriptEntry = None
         if role == "human":
             while self.chat_history and self.chat_history[-1][0] == "human":
                 self.chat_history.pop()
@@ -641,6 +653,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
             role != "message.bot"
         ):  # we dont add it here, we add it as its said in streaming convo
             self.chat_history.append((role, message))
+
         if role == "action-finish":
             self.json_transcript.entries.append(
                 StateAgentTranscriptActionFinish(
@@ -651,12 +664,19 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                 )
             )
         else:
-            self.json_transcript.entries.append(
-                StateAgentTranscriptMessage(role=role, message=message)
+
+            TranscriptEntry = StateAgentTranscriptMessage(
+                role=role, message=message, message_sent=""
             )
+            if len(state_agent_transcript_messages_added) > 0 and not speak:
+                self.json_transcript.entries.extend(
+                    state_agent_transcript_messages_added
+                )
+            else:
+                self.json_transcript.entries.append(TranscriptEntry)
 
+        self.logger.info(f"{role=}, {message=}, {speak=}, {TranscriptEntry=}")
         if role == "message.bot" and len(message.strip()) > 0 and speak:
-
             self.produce_interruptible_agent_response_event_nonblocking(
                 AgentResponseMessage(
                     message=BaseMessage(
@@ -665,6 +685,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                         )
                     )
                 ),
+                json_transcript_entry=TranscriptEntry,
                 agent_response_tracker=agent_response_tracker,
             )
 
@@ -770,6 +791,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         is_start=False,
         memory_id=None,
         speak=True,
+        state_agent_transcript_messages_added: List[StateAgentTranscriptMessage] = [],
     ):
         if is_start:
             current_state_id = current_state_id + "_start"
@@ -782,7 +804,12 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
             self.logger.info(
                 f"Updating history with message: {message['message']} with speak {speak}"
             )
-            self.update_history("message.bot", message["message"], speak=speak)
+            self.update_history(
+                "message.bot",
+                message["message"],
+                speak=speak,
+                state_agent_transcript_messages_added=state_agent_transcript_messages_added,
+            )
         else:
             guide = message["description"]
             await self.guided_response(guide)
@@ -826,7 +853,9 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                 f"'invalid_answer' - if the user provided an answer but it wasn't a valid or relevant response to the specific question.\n"
                 f"'continue' - if none of the above apply."
             )
-            response, streamed = await self.call_ai(prompt, stream_output=True)
+            response, state_agent_transcript_messages_added, streamed = (
+                await self.call_ai(prompt, stream_output=True)
+            )
             self.logger.info(f"Initial intent analysis response: {response}")
             intent = response.strip().lower()
             if intent not in [
@@ -858,7 +887,9 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
             f"'continue' - if the user's message is relevant to the current intent and they are engaged in the conversation (e.g. asking follow-up questions or providing additional context) but none of the above apply."
         )
 
-        response, streamed = await self.call_ai(prompt, stream_output=True)
+        response, state_agent_transcript_messages_added, streamed = await self.call_ai(
+            prompt, stream_output=True
+        )
         self.logger.info(f"Analyze user intent prompt response: {response}")
         intent = response.strip().lower()
         if intent not in [
@@ -973,11 +1004,12 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                         state_id_or_label=state_id_or_label, retry_count=new_retry_count
                     )
 
-                speak_message = lambda message, streamed: self.print_message(
+                speak_message = lambda message, streamed, state_agent_transcript_messages_added: self.print_message(
                     message,
                     state["id"],
                     memory_id=memory_dep["key"] + "_memory",
                     speak=not streamed,
+                    state_agent_transcript_messages_added=state_agent_transcript_messages_added,
                 )
                 try:
                     return await handle_memory_dep(
@@ -1147,9 +1179,11 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
             prompt += f"Bot's is thinking: '{bot_message_after_user}'\n"
         prompt += "\nNow, respond as the BOT directly."
 
-        message, streamed = await self.call_ai(prompt, stream_output=True)
+        message, state_agent_transcript_messages_added, streamed = await self.call_ai(
+            prompt, stream_output=True
+        )
         message = message.strip()
-        self.logger.info(f"Guided response: {message}")
+        self.logger.info(f"Guided response: {message}, {streamed=}")
         self.update_history("message.bot", message)
         return message, streamed
 
@@ -1225,10 +1259,12 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
 
             if dict_to_fill:
                 param_descriptions_str = "\n".join(param_descriptions)
-                response, streamed = await self.call_ai(
-                    prompt=f"Based on the current conversation and the instructions provided, return a valid json with values inserted for these parameters:\n{param_descriptions_str}",
-                    tool=dict_to_fill,
-                    stream_output=True,
+                response, state_agent_transcript_messages_added, streamed = (
+                    await self.call_ai(
+                        prompt=f"Based on the current conversation and the instructions provided, return a valid json with values inserted for these parameters:\n{param_descriptions_str}",
+                        tool=dict_to_fill,
+                        stream_output=True,
+                    )
                 )
                 self.logger.info(f"Raw AI response: {response}")
                 response = response[response.find("{") : response.rfind("}") + 1]
@@ -1365,6 +1401,8 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
         response_text = ""
         streamed = False
         start_time = time.time()
+
+        state_agent_transcript_messages_added = []
 
         # Extract the last sequence of bot, user, bot messages
         last_bot_messages_before = []
@@ -1558,10 +1596,20 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                                 self.logger.info(
                                     f"streaming content. Raw: {content}  interpolated: {interpolated_content}"
                                 )
+                                TranscriptMessage = StateAgentTranscriptMessage(
+                                    role="message.bot",
+                                    message=interpolated_content,
+                                    message_sent=interpolated_content,
+                                )
+                                state_agent_transcript_messages_added.append(
+                                    TranscriptMessage
+                                )
+
                                 self.produce_interruptible_agent_response_event_nonblocking(
                                     AgentResponseMessage(
                                         message=BaseMessage(text=interpolated_content)
-                                    )
+                                    ),
+                                    json_transcript_entry=TranscriptMessage,
                                 )
                                 if not first_response_sent:
                                     # Update average latency on first response for streaming
@@ -1583,6 +1631,8 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                 and send_final_message
                 and buffer.strip() != '"}'
                 and buffer.strip() != "}"
+                and buffer.strip() != '"}\n```'
+                # https://app.opencall.ai/console/calls/WzEsICJwdWJsaWMiLCAiY2FsbF9kZXRhaWxzIiwgODU4OTZd
             ):
                 # if there is just one double quote in the whole thing, remove it
                 if buffer.strip().count('"') == 1:
@@ -1593,8 +1643,18 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                 self.logger.info(
                     f"Streaming final message. Raw: {buffer}  interpolated: {interpolated_content}"
                 )
+                # Need to pass the same object to the json transcript and the produce_interruptible_agent_response_event_nonblocking
+                TranscriptMessage = StateAgentTranscriptMessage(
+                    role="message.bot",
+                    message=interpolated_content,
+                    message_sent=interpolated_content,
+                )
+                state_agent_transcript_messages_added.append(TranscriptMessage)
                 self.produce_interruptible_agent_response_event_nonblocking(
-                    AgentResponseMessage(message=BaseMessage(text=interpolated_content))
+                    AgentResponseMessage(
+                        message=BaseMessage(text=interpolated_content)
+                    ),
+                    json_transcript_entry=TranscriptMessage,
                 )
                 if not first_response_sent:
                     # Update average latency if we haven't sent any responses yet
@@ -1608,6 +1668,7 @@ class StateAgent(RespondAgent[CommandAgentConfig]):
                 streamed = True
         return (
             interpolate_memories.interpolate_memories(response_text, self.memories),
+            state_agent_transcript_messages_added,
             streamed,
         )
 

--- a/vocode/streaming/models/state_agent_transcript.py
+++ b/vocode/streaming/models/state_agent_transcript.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field, root_validator
+
 from vocode.streaming.models.memory_dependency import MemoryDependency
 
 
@@ -42,6 +43,7 @@ class StateAgentTranscriptEntry(BaseModel):
 class StateAgentTranscriptMessage(StateAgentTranscriptEntry):
     role: StateAgentTranscriptRole
     message: str
+    message_sent: str
     timestamp: str = Field(default_factory=lambda: datetime.datetime.now().isoformat())
 
     class Config:

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -7,10 +7,11 @@ import queue
 import random
 import threading
 import time
+import traceback
 import typing
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Awaitable, Callable, Generic, Optional, Tuple, TypeVar
+from typing import Any, Awaitable, Callable, Dict, Generic, Optional, Tuple, TypeVar
 
 import httpx
 from telephony_app.models.call_type import CallType
@@ -37,7 +38,11 @@ from vocode.streaming.constants import (
 from vocode.streaming.models.agent import FillerAudioConfig
 from vocode.streaming.models.events import Sender
 from vocode.streaming.models.message import BaseMessage
-from vocode.streaming.models.state_agent_transcript import StateAgentTranscript
+from vocode.streaming.models.state_agent_transcript import (
+    StateAgentTranscript,
+    StateAgentTranscriptEntry,
+    StateAgentTranscriptMessage,
+)
 from vocode.streaming.models.synthesizer import SentimentConfig
 from vocode.streaming.models.transcriber import TranscriberConfig
 from vocode.streaming.models.transcript import (
@@ -101,11 +106,13 @@ class StreamingConversation(Generic[OutputDeviceType]):
             payload: Any,
             is_interruptible: bool = True,
             agent_response_tracker: Optional[asyncio.Event] = None,
+            json_transcript_entry: Optional[StateAgentTranscriptMessage] = None,
         ) -> InterruptibleAgentResponseEvent:
             interruptible_event = super().create_interruptible_agent_response_event(
                 payload,
                 is_interruptible=is_interruptible,
                 agent_response_tracker=agent_response_tracker,
+                json_transcript_entry=json_transcript_entry,
             )
             self.conversation.interruptible_events.put_nowait(interruptible_event)
             return interruptible_event
@@ -732,6 +739,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 return
             try:
                 agent_response = item.payload
+                json_transcript_entry = item.json_transcript_entry
                 if isinstance(agent_response, AgentResponseFillerAudio):
                     self.send_filler_audio(item.agent_response_tracker)
                     return
@@ -820,6 +828,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                         (agent_response_message.message, synthesis_result),
                         is_interruptible=item.is_interruptible,
                         agent_response_tracker=item.agent_response_tracker,
+                        json_transcript_entry=json_transcript_entry,
                     )
                     # self.conversation.logger.info(
                     #     f"[{self.conversation.agent.agent_config.call_type}:{self.conversation.agent.agent_config.current_call_id}] Agent: {agent_response_message.message.text}"
@@ -829,7 +838,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                         f"SYNTH: WAS NOT COMMAND AGENT, {agent_response_message.message.text}"
                     )
             except asyncio.CancelledError:
-                pass
+                self.conversation.logger.warning("Agent responses worker cancelled")
 
     class SynthesisResultsWorker(InterruptibleAgentResponseWorker):
         """Worker class responsible for playing synthesized speech results.
@@ -859,6 +868,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             try:
                 # Unpack the message and synthesis result from the event payload.
                 message, synthesis_result = item.payload
+                json_transcript_entry = item.json_transcript_entry
 
                 # Initialize a transcript message with an empty text, which will be updated later.
                 transcript_message = Message(
@@ -880,6 +890,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.conversation.started_event,
                     TEXT_TO_SPEECH_CHUNK_SIZE_SECONDS,
                     transcript_message=transcript_message,
+                    json_transcript_entry=json_transcript_entry,
                 )
                 # Create an asynchronous task for the coroutine and store it as the current task.
                 self.current_task = asyncio.create_task(send_speech_coroutine)
@@ -902,8 +913,15 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.conversation.started_event.clear()
                     self.current_task = None
                 except Exception as e:
+                    if isinstance(e, asyncio.CancelledError):
+                        self.conversation.logger.info(
+                            f"Cancelled Synthesis Results Worker Task"
+                        )
+                    else:
+                        self.conversation.logger.warning(
+                            f"Synthesis Results Worker current_task error: {e}"
+                        )
                     # If an exception occurs, log it and set the message as cut off.
-                    self.conversation.logger.debug(f"Detected Task cancelled: {e}")
                     message_sent, cut_off = "", True
                     self.current_task = None
                     return
@@ -959,7 +977,15 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     except asyncio.TimeoutError:
                         # If the goodbye detection task times out, simply pass.
                         pass
-            except asyncio.CancelledError:
+            except Exception as e:
+                if isinstance(e, asyncio.CancelledError):
+                    self.conversation.logger.info(
+                        f"Synthesis results worker cancelled: {e}"
+                    )
+                else:
+                    self.conversation.logger.warning(
+                        f"Error in synthesis results worker: {e}"
+                    )
                 # If the task was cancelled, do nothing.
                 self.current_task = None
                 pass
@@ -981,6 +1007,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             logger or logging.getLogger(__name__),
             conversation_id=self.id,
         )
+        self.logger.setLevel(logging.INFO)
         self.conversation_span = tracer.start_span(f"conversation::{self.id}")
         self.logger.debug(f"Conversation ID: {self.id}")
         # threadingevent
@@ -990,6 +1017,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.output_device = output_device
         self.transcriber = transcriber
         self.turn_speech_time = 0.0
+        self.json_transcript_history: dict[str, dict] = {}
 
         self.agent = agent
         self.synthesizer = synthesizer
@@ -1375,6 +1403,16 @@ class StreamingConversation(Generic[OutputDeviceType]):
             return 0
         return time.perf_counter() - time_started_speaking
 
+    def set_message_sent_on_interrupt(
+        self,
+        duration_spoken_seconds: float,
+        json_transcript_entry: StateAgentTranscriptMessage,
+        synthesis_result: SynthesisResult,
+    ):
+        message_sent = synthesis_result.get_message_up_to(duration_spoken_seconds)
+        self.logger.info(f"Message sent on interrupt: {message_sent}")
+        json_transcript_entry.message_sent = message_sent
+
     async def send_speech_to_output(
         self,
         message: str,
@@ -1382,11 +1420,22 @@ class StreamingConversation(Generic[OutputDeviceType]):
         stop_event: threading.Event,
         started_event: threading.Event,
         seconds_per_chunk: int,
+        json_transcript_entry: Optional[StateAgentTranscriptMessage] = None,
         transcript_message: Optional[Message] = None,
     ):
+
         if not (synthesis_result and message):
             return "", False
         stop_event.clear()
+        transcript = deepcopy(self.agent.get_json_transcript())
+        transcript_dict = transcript.dict()
+        filtered_entries = [
+            entry
+            for entry in transcript_dict["entries"]
+            if entry["role"] in ["message.bot", "human"]
+        ]
+        transcript_dict["entries"] = filtered_entries
+        self.json_transcript_history[time.perf_counter()] = transcript_dict
 
         self.transcriptions_worker.synthesis_done = False
         message_sent = message
@@ -1408,6 +1457,11 @@ class StreamingConversation(Generic[OutputDeviceType]):
         async for chunk_result in synthesis_result.chunk_generator:
 
             if stop_event.is_set() and self.agent.agent_config.allow_interruptions:
+                self.set_message_sent_on_interrupt(
+                    self.get_duration_spoken_seconds(time_started_speaking),
+                    json_transcript_entry,
+                    synthesis_result,
+                )
                 return "", False
 
             speech_data.extend(chunk_result.chunk)
@@ -1424,6 +1478,12 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.mark_last_action_timestamp()
 
                     if stop_event.is_set():
+                        self.set_message_sent_on_interrupt(
+                            self.get_duration_spoken_seconds(time_started_speaking),
+                            json_transcript_entry,
+                            synthesis_result,
+                        )
+
                         # self.agent.move_back_state()
                         self.logger.debug(
                             "Moved back state from send_speech_to_output in the middle"
@@ -1443,11 +1503,15 @@ class StreamingConversation(Generic[OutputDeviceType]):
             self.logger.debug(f"Sending final chunk, len {len(speech_data)}")
             await self.output_device.consume_nonblocking(speech_data)
             self.transcriptions_worker.time_silent = 0.0
+            # TODO this is wrong, we should not use chunk_size here
             total_time_sent += len(speech_data) / (chunk_size / seconds_per_chunk)
         else:
             self.logger.debug("Interrupted speech output on the last chunk")
-            # if not moved_back:
-            #     self.agent.move_back_state()
+            self.set_message_sent_on_interrupt(
+                self.get_duration_spoken_seconds(time_started_speaking),
+                json_transcript_entry,
+                synthesis_result,
+            )
             return "", False
 
         self.transcriptions_worker.synthesis_done = True
@@ -1480,13 +1544,21 @@ class StreamingConversation(Generic[OutputDeviceType]):
             await asyncio.sleep(next_sleep)
             if stop_event.is_set():
                 self.logger.debug("Interrupted speech output on the last chunk")
-                # self.agent.move_back_state()
+                self.set_message_sent_on_interrupt(
+                    self.get_duration_spoken_seconds(time_started_speaking),
+                    json_transcript_entry,
+                    synthesis_result,
+                )
                 return "", False
             self.mark_last_action_timestamp()
             self.turn_speech_time += next_sleep
             remaining_sleep -= next_sleep
-            # message_sent = synthesis_result.get_message_up_to(self.get_duration_spoken_seconds(time_started_speaking))
-            # self.logger.info(f"{message_sent=} {self.get_duration_spoken_seconds(time_started_speaking)=}")
+            # message_sent = synthesis_result.get_message_up_to(
+            #     self.get_duration_spoken_seconds(time_started_speaking)
+            # )
+            # self.logger.info(
+            #     f"{message_sent=} {self.get_duration_spoken_seconds(time_started_speaking)=}"
+            # )
             if self.turn_speech_time > 3:
                 self.logger.debug(f"Turn speech time: {self.turn_speech_time}")
                 buffer_cleared = True
@@ -1541,13 +1613,26 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.logger.debug("Unmuting transcriber")
                     self.transcriber.unmute()
         self.transcriptions_worker.ready_to_send = BufferStatus.DISCARD
-
+        if json_transcript_entry:
+            json_transcript_entry.message = message_sent
         return message_sent, cut_off
 
     def mark_terminated(self):
         self.active = False
 
     async def terminate(self):
+        self.logger.debug("Terminating conversation")
+        with open("/code/telephony_app/transcript_history.json", "w") as f:
+            json.dump(
+                self.json_transcript_history,
+                f,
+                indent=6,
+            )
+
+        self.logger.warning(
+            "Json transcript history written to transcript_history.json"
+        )
+
         self.mark_terminated()
         end_span(self.conversation_span)
         await self.broadcast_interrupt()

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -1604,7 +1604,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
             self.logger.debug("Cleared buffer from send_speech_to_output")
 
-            # self.agent.restore_resume_state()
+        # self.agent.restore_resume_state()
 
         if message_sent:
             if self.allow_unmute:
@@ -1614,7 +1614,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.transcriber.unmute()
         self.transcriptions_worker.ready_to_send = BufferStatus.DISCARD
         if json_transcript_entry:
-            json_transcript_entry.message = message_sent
+            json_transcript_entry.message_sent = message_sent
         return message_sent, cut_off
 
     def mark_terminated(self):

--- a/vocode/streaming/telephony/conversation/call.py
+++ b/vocode/streaming/telephony/conversation/call.py
@@ -54,7 +54,7 @@ class Call(StreamingConversation[TelephonyOutputDeviceType]):
             logger or logging.getLogger(__name__),
             conversation_id=conversation_id,
         )
-        logger.setLevel(logging.INFO)
+        # logger.setLevel(logging.INFO)
 
         self.from_phone = from_phone
         self.to_phone = to_phone

--- a/vocode/streaming/telephony/conversation/call.py
+++ b/vocode/streaming/telephony/conversation/call.py
@@ -1,32 +1,30 @@
 from __future__ import annotations
-from asyncio import iscoroutine
-from fastapi import WebSocket
-from enum import Enum
+
 import logging
+from asyncio import iscoroutine
+from enum import Enum
 from typing import Optional, TypeVar, Union
+
+from fastapi import WebSocket
+
 from vocode.streaming.agent.base_agent import BaseAgent
 from vocode.streaming.agent.factory import AgentFactory
 from vocode.streaming.models.agent import AgentConfig
 from vocode.streaming.models.events import PhoneCallEndedEvent
-from vocode.streaming.output_device.vonage_output_device import VonageOutputDevice
-
-from vocode.streaming.streaming_conversation import StreamingConversation
+from vocode.streaming.models.synthesizer import SynthesizerConfig
+from vocode.streaming.models.transcriber import TranscriberConfig
 from vocode.streaming.output_device.twilio_output_device import TwilioOutputDevice
-from vocode.streaming.models.synthesizer import (
-    SynthesizerConfig,
-)
-from vocode.streaming.models.transcriber import (
-    TranscriberConfig,
-)
+from vocode.streaming.output_device.vonage_output_device import VonageOutputDevice
+from vocode.streaming.streaming_conversation import StreamingConversation
 from vocode.streaming.synthesizer.factory import SynthesizerFactory
 from vocode.streaming.telephony.config_manager.base_config_manager import (
     BaseConfigManager,
 )
 from vocode.streaming.telephony.constants import DEFAULT_SAMPLING_RATE
 from vocode.streaming.transcriber.factory import TranscriberFactory
-from vocode.streaming.utils.events_manager import EventsManager
-from vocode.streaming.utils.conversation_logger_adapter import wrap_logger
 from vocode.streaming.utils import create_conversation_id
+from vocode.streaming.utils.conversation_logger_adapter import wrap_logger
+from vocode.streaming.utils.events_manager import EventsManager
 
 TelephonyOutputDeviceType = TypeVar(
     "TelephonyOutputDeviceType", bound=Union[TwilioOutputDevice, VonageOutputDevice]
@@ -56,6 +54,7 @@ class Call(StreamingConversation[TelephonyOutputDeviceType]):
             logger or logging.getLogger(__name__),
             conversation_id=conversation_id,
         )
+        logger.setLevel(logging.INFO)
 
         self.from_phone = from_phone
         self.to_phone = to_phone


### PR DESCRIPTION
@bluegoo192 Still shoring this up just want you to take a glimpse at the approach. 

main changes are to `update_history`, and `call_ai`.
update_history takes a list of StateAgentTranscriptMessage. this is used to pass the mutable objects (StateAgentTranscriptMessages) from call_ai so we have the ability to update the message_sent from streaming conversation and have it correlate to an entry in the json_transcript. 

An alternative, is to always update the json transcript when we call `produce_interruptible_agent_response_event_nonblocking`
___

Previous Comment: 3 days ago
Sets the message_sent for the json transcript.  
~60 test calls so far. Tested interruptions on basic states, memories and actions. 

Much more comparison testing required. Some untested areas include:
- Streaming off
- Interruptions off
- Outbound calls
  - Outbound start messages
- Option states
- Question states
- Message to Say on memory states.
- Production Agents (Made an agent to test this. Should run calls on production agents). 